### PR TITLE
Check if mobile users use Metamask 

### DIFF
--- a/frontend/cult-donations-ui/src/components/invitations/Explanation.svelte
+++ b/frontend/cult-donations-ui/src/components/invitations/Explanation.svelte
@@ -10,7 +10,9 @@
     const isVisitorOnMobileDevice = () => {
         // alert("hier")
         // alert(!!navigator.userAgent.match(/iphone|android|blackberry/ig) || false)
-        metamaskMobileBrowserRecommendationNeeded = !!navigator.userAgent.match(/iphone|android|blackberry/ig) || false;
+        const hasEthereum = window.ethereum == undefined ? false : true;
+		const isMobile = !!navigator.userAgent.match(/iphone|android|blackberry/ig) || false;
+        metamaskMobileBrowserRecommendationNeeded = !hasEthereum && isMobile;
     };
 
 </script>


### PR DESCRIPTION
By checking if the mobile user has access to window.ethereum, you can determine if they are using Metamask so that the notice is only displayed if the user is using a default browser. 